### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ modify it to make it do what you want it to do. `AppDelegate.m` and
 
 ### Including it in your own application
 
-Install [Cocoapods](https://guides.cocoapods.org/using/getting-started.html) and add the following line to your project's Podfile:
+Install [CocoaPods](https://guides.cocoapods.org/using/getting-started.html) and add the following line to your project's Podfile:
 
 ```
 pod "libmuse", :git => 'https://github.com/monchote/libmuse.git'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
